### PR TITLE
Migrate to gcdExt from semirings package

### DIFF
--- a/galois-field.cabal
+++ b/galois-field.cabal
@@ -70,7 +70,7 @@ library
     , poly            >=0.3.2  && <0.4
     , protolude       >=0.2    && <0.3
     , QuickCheck      >=2.13   && <2.14
-    , semirings       >=0.5    && <0.6
+    , semirings       >=0.5.2  && <0.6
     , vector          >=0.12.0 && <0.13
     , wl-pprint-text  >=1.2.0  && <1.3
 

--- a/src/Data/Field/Galois/Extension.hs
+++ b/src/Data/Field/Galois/Extension.hs
@@ -19,10 +19,10 @@ module Data.Field.Galois.Extension
 import Protolude as P hiding (Semiring, rem, toList)
 
 import Control.Monad.Random (Random(..))
-import Data.Euclidean (Euclidean(..), GcdDomain)
+import Data.Euclidean (Euclidean(..), GcdDomain, gcdExt)
 import Data.Field (Field)
 import Data.Group (Group(..))
-import Data.Poly (VPoly, gcdExt, monomial, toPoly, unPoly)
+import Data.Poly (VPoly, monomial, toPoly, unPoly, scale, leading)
 import Data.Semiring (Ring(..), Semiring(..))
 import GHC.Exts (IsList(..))
 import Test.QuickCheck (Arbitrary(..), vector)
@@ -103,9 +103,11 @@ instance IrreducibleMonic p k => Semigroup (Extension p k) where
 
 -- Extension fields are fractional.
 instance IrreducibleMonic p k => Fractional (Extension p k) where
-  recip (E x)         = case gcdExt x $ poly (witness :: Extension p k) of
-    (1, y) -> E y
-    _      -> divZeroError
+  recip (E x) = case leading g of
+    Just (0, c) -> E $ scale 0 (recip c) y
+    _           -> divZeroError
+    where
+      (g, y) = gcdExt x $ poly (witness :: Extension p k)
   {-# INLINABLE recip #-}
   fromRational (x:%y) = fromInteger x / fromInteger y
   {-# INLINABLE fromRational #-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,5 +2,6 @@ resolver: lts-14.7
 extra-deps:
   - bitvec-1.0.2.0
   - mod-0.1.0.0
-  - poly-0.3.2.0
-  - semirings-0.5.1
+  - poly-0.3.3.0
+  - semirings-0.5.3
+  - vector-algorithms-0.8.0.3

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -19,19 +19,26 @@ packages:
   original:
     hackage: mod-0.1.0.0
 - completed:
-    hackage: poly-0.3.2.0@sha256:2cba686238c5074d551a56375f441b18745fbc465cdc3e0acf1701ae928f3ae9,1918
+    hackage: poly-0.3.3.0@sha256:49657d89a3abf9f973fe4be792103642eee9d17e32ea37339f50081c87196447,2021
     pantry-tree:
-      size: 1451
-      sha256: 0a08b17044344cfa9923aefddad623987d12ed2d25738f5acb46f2ec71f8610d
+      size: 1453
+      sha256: 785951b65ec658bbf55e10575cd921b3ade75e71147d10e59784f68e7c255163
   original:
-    hackage: poly-0.3.2.0
+    hackage: poly-0.3.3.0
 - completed:
-    hackage: semirings-0.5.1@sha256:597e4070dcb75c3e347566114e140ba343843f80f3e16a456bb2e9e9d1d09430,3743
+    hackage: semirings-0.5.3@sha256:4b0d243f88bb07c0673978a37b6b9fd16da44f15e8d552fb08795d9a88a3dc76,3791
     pantry-tree:
       size: 610
-      sha256: cc4e01176f1a56c97dc923416a6939dcdc004584cccf8a2b1c67bd156b31179a
+      sha256: 0bc3f63a3b92be1c6be2e36c7db8df62e61b2860eba7f083b84e2b16dbaa2d69
   original:
-    hackage: semirings-0.5.1
+    hackage: semirings-0.5.3
+- completed:
+    hackage: vector-algorithms-0.8.0.3@sha256:477ef5ac82fdd28a39536ed0a767faec3425802827abee485be31db5bc6f5e90,3488
+    pantry-tree:
+      size: 1439
+      sha256: 9f04ef44c2459a122f2d5c093b4a9ebc47aaa00284a7bff9793fee7c6783f979
+  original:
+    hackage: vector-algorithms-0.8.0.3
 snapshots:
 - completed:
     size: 523700


### PR DESCRIPTION
In the next major release of `poly` I intend to remove [`Data.Poly.gcdExt`](http://hackage.haskell.org/package/poly-0.3.3.0/docs/Data-Poly.html#v:gcdExt) in favor of [`Data.Euclidean.gcdExt`](http://hackage.haskell.org/package/semirings-0.5.3/docs/Data-Euclidean.html#v:gcdExt) from `semirings`. The latter works uniformly for any euclidean ring and `poly` depends on `semirings` anyways, so it is redundant to have another implementation, specific to polynomials.

The caveat is that since `Data.Euclidean.gcdExt` is polymorphic over `Euclidean` `Ring`, it knows nothing about units of the ring and cannot normalise its output. So the gcd of two coprime elements may appear to be not only `1`, but also `-1` or potentially any other unit. In constrast to this, `Data.Poly.gcdExt` was defined only for polynomials over fields and so was always able to normalise the leading coefficient to `1`. 

See also discussion at https://github.com/Bodigrim/poly/issues/38

This commit migrates `galois-field` to use `gcdExt` from `Data.Euclidean` and amends source code to match previous behaviour. (I'm not sure whether such changes should be reflected in the changelog, so I left it unchanged for now)