### PR TITLE
Updates to support serilization

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Change log for galois-field
 
+## 1.0.3
+
+* Add `fromU` for RootsOfUnity
+* Update to support removal of :% for Rational from Protolude 0.3
+
 ## 1.0.2
 
 * Add `Mod` dependency for prime fields.

--- a/galois-field.cabal
+++ b/galois-field.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ff961a8802a0393916ed1a5cdc25f4065f9475f69e2ddc8ced5a0a0eff98b630
+-- hash: d489cc761a0b72219cc46f61de6816a942552d22df093c469f043793bff39ada
 
 name:               galois-field
-version:            1.0.2
+version:            1.0.3
 synopsis:           Galois field library
 description:        An efficient implementation of Galois fields used in cryptography research
 category:           Cryptography

--- a/galois-field.cabal
+++ b/galois-field.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 5a4ff8202103660ef153acd7e5679e59c9b53d601f6963fda79e8b2f37d5831e
+-- hash: ff961a8802a0393916ed1a5cdc25f4065f9475f69e2ddc8ced5a0a0eff98b630
 
 name:               galois-field
 version:            1.0.2
@@ -50,7 +50,7 @@ library
     , integer-gmp >=1.0.2 && <1.1
     , mod >=0.1.0 && <0.2
     , poly >=0.3.2 && <0.5
-    , protolude >=0.2 && <0.3
+    , protolude >=0.2 && <0.4
     , semirings >=0.5 && <0.6
     , vector >=0.12.0 && <0.13
     , wl-pprint-text >=1.2.0 && <1.3
@@ -79,7 +79,7 @@ test-suite galois-field-tests
     , integer-gmp >=1.0.2 && <1.1
     , mod >=0.1.0 && <0.2
     , poly >=0.3.2 && <0.5
-    , protolude >=0.2 && <0.3
+    , protolude >=0.2 && <0.4
     , semirings >=0.5 && <0.6
     , tasty >=1.2 && <1.3
     , tasty-quickcheck >=0.10 && <0.11
@@ -111,7 +111,7 @@ benchmark galois-field-benchmarks
     , integer-gmp >=1.0.2 && <1.1
     , mod >=0.1.0 && <0.2
     , poly >=0.3.2 && <0.5
-    , protolude >=0.2 && <0.3
+    , protolude >=0.2 && <0.4
     , semirings >=0.5 && <0.6
     , vector >=0.12.0 && <0.13
     , wl-pprint-text >=1.2.0 && <1.3

--- a/galois-field.cabal
+++ b/galois-field.cabal
@@ -1,17 +1,15 @@
-cabal-version:      1.12
+cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.34.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4f1f517ac1812c3cb4f6bd4c78c3091393d6c7708ce11feb2729ac6f871f92c4
+-- hash: 5a4ff8202103660ef153acd7e5679e59c9b53d601f6963fda79e8b2f37d5831e
 
 name:               galois-field
 version:            1.0.2
 synopsis:           Galois field library
-description:
-  An efficient implementation of Galois fields used in cryptography research
-
+description:        An efficient implementation of Galois fields used in cryptography research
 category:           Cryptography
 homepage:           https://github.com/adjoint-io/galois-field#readme
 bug-reports:        https://github.com/adjoint-io/galois-field/issues
@@ -20,157 +18,101 @@ license:            MIT
 license-file:       LICENSE
 build-type:         Simple
 extra-source-files:
-  README.notex.md
-  ChangeLog.md
+    README.notex.md
+    ChangeLog.md
 
 source-repository head
-  type:     git
+  type: git
   location: https://github.com/adjoint-io/galois-field
 
 library
-  exposed-modules:    Data.Field.Galois
+  exposed-modules:
+      Data.Field.Galois
   other-modules:
-    Data.Field.Galois.Base
-    Data.Field.Galois.Binary
-    Data.Field.Galois.Extension
-    Data.Field.Galois.Frobenius
-    Data.Field.Galois.Prime
-    Data.Field.Galois.Sqrt
-    Data.Field.Galois.Tower
-    Data.Field.Galois.Unity
-
-  hs-source-dirs:     src
-  default-extensions:
-    NoImplicitPrelude
-    DataKinds
-    DeriveFunctor
-    DeriveGeneric
-    FlexibleContexts
-    FlexibleInstances
-    GeneralizedNewtypeDeriving
-    KindSignatures
-    LambdaCase
-    MultiParamTypeClasses
-    OverloadedLists
-    OverloadedStrings
-    PatternSynonyms
-    RankNTypes
-    RecordWildCards
-    ScopedTypeVariables
-    TypeFamilies
-
-  ghc-options:        -freverse-errors -O2 -Wall
+      Data.Field.Galois.Base
+      Data.Field.Galois.Binary
+      Data.Field.Galois.Extension
+      Data.Field.Galois.Frobenius
+      Data.Field.Galois.Prime
+      Data.Field.Galois.Sqrt
+      Data.Field.Galois.Tower
+      Data.Field.Galois.Unity
+  hs-source-dirs:
+      src
+  default-extensions: LambdaCase RecordWildCards OverloadedStrings NoImplicitPrelude FlexibleInstances FlexibleContexts ScopedTypeVariables RankNTypes DataKinds DeriveFunctor DeriveGeneric GeneralizedNewtypeDeriving KindSignatures MultiParamTypeClasses OverloadedLists PatternSynonyms TypeFamilies
+  ghc-options: -freverse-errors -O2 -Wall
   build-depends:
-      base            >=4.10   && <5
-    , bitvec          >=1.0.2  && <1.1
-    , groups          >=0.4.1  && <0.5
-    , integer-gmp     >=1.0.2  && <1.1
-    , mod             >=0.1.0  && <0.2
-    , MonadRandom     >=0.5.1  && <0.6
-    , poly            >=0.3.2  && <0.5
-    , protolude       >=0.2    && <0.4
-    , QuickCheck      >=2.13   && <2.14
-    , semirings       >=0.5    && <0.6
-    , vector          >=0.12.0 && <0.13
-    , wl-pprint-text  >=1.2.0  && <1.3
-
-  default-language:   Haskell2010
+      MonadRandom >=0.5.1 && <0.6
+    , QuickCheck >=2.13 && <2.14
+    , base >=4.10 && <5
+    , bitvec >=1.0.2 && <1.1
+    , groups >=0.4.1 && <0.5
+    , integer-gmp >=1.0.2 && <1.1
+    , mod >=0.1.0 && <0.2
+    , poly >=0.3.2 && <0.5
+    , protolude >=0.2 && <0.3
+    , semirings >=0.5 && <0.6
+    , vector >=0.12.0 && <0.13
+    , wl-pprint-text >=1.2.0 && <1.3
+  default-language: Haskell2010
 
 test-suite galois-field-tests
-  type:               exitcode-stdio-1.0
-  main-is:            Main.hs
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
   other-modules:
-    Paths_galois_field
-    Test.Binary
-    Test.Extension
-    Test.Galois
-    Test.Prime
-
-  hs-source-dirs:     test
-  default-extensions:
-    NoImplicitPrelude
-    DataKinds
-    DeriveFunctor
-    DeriveGeneric
-    FlexibleContexts
-    FlexibleInstances
-    GeneralizedNewtypeDeriving
-    KindSignatures
-    LambdaCase
-    MultiParamTypeClasses
-    OverloadedLists
-    OverloadedStrings
-    PatternSynonyms
-    RankNTypes
-    RecordWildCards
-    ScopedTypeVariables
-    TypeFamilies
-
-  ghc-options:        -freverse-errors -O2 -Wall -main-is Main
+      Test.Binary
+      Test.Extension
+      Test.Galois
+      Test.Prime
+      Paths_galois_field
+  hs-source-dirs:
+      test
+  default-extensions: LambdaCase RecordWildCards OverloadedStrings NoImplicitPrelude FlexibleInstances FlexibleContexts ScopedTypeVariables RankNTypes DataKinds DeriveFunctor DeriveGeneric GeneralizedNewtypeDeriving KindSignatures MultiParamTypeClasses OverloadedLists PatternSynonyms TypeFamilies
+  ghc-options: -freverse-errors -O2 -Wall -main-is Main
   build-depends:
-      base              >=4.10   && <5
-    , bitvec            >=1.0.2  && <1.1
+      MonadRandom >=0.5.1 && <0.6
+    , QuickCheck >=2.13 && <2.14
+    , base >=4.10 && <5
+    , bitvec >=1.0.2 && <1.1
     , galois-field
-    , groups            >=0.4.1  && <0.5
-    , integer-gmp       >=1.0.2  && <1.1
-    , mod               >=0.1.0  && <0.2
-    , MonadRandom       >=0.5.1  && <0.6
-    , poly              >=0.3.2  && <0.5
-    , protolude         >=0.2    && <0.4
-    , QuickCheck        >=2.13   && <2.14
-    , semirings         >=0.5    && <0.6
-    , tasty             >=1.2    && <1.3
-    , tasty-quickcheck  >=0.10   && <0.11
-    , vector            >=0.12.0 && <0.13
-    , wl-pprint-text    >=1.2.0  && <1.3
-
-  default-language:   Haskell2010
+    , groups >=0.4.1 && <0.5
+    , integer-gmp >=1.0.2 && <1.1
+    , mod >=0.1.0 && <0.2
+    , poly >=0.3.2 && <0.5
+    , protolude >=0.2 && <0.3
+    , semirings >=0.5 && <0.6
+    , tasty >=1.2 && <1.3
+    , tasty-quickcheck >=0.10 && <0.11
+    , vector >=0.12.0 && <0.13
+    , wl-pprint-text >=1.2.0 && <1.3
+  default-language: Haskell2010
 
 benchmark galois-field-benchmarks
-  type:               exitcode-stdio-1.0
-  main-is:            Main.hs
+  type: exitcode-stdio-1.0
+  main-is: Main.hs
   other-modules:
-    Bench.Binary
-    Bench.Extension
-    Bench.Galois
-    Bench.Prime
-    Paths_galois_field
-
-  hs-source-dirs:     bench
-  default-extensions:
-    NoImplicitPrelude
-    DataKinds
-    DeriveFunctor
-    DeriveGeneric
-    FlexibleContexts
-    FlexibleInstances
-    GeneralizedNewtypeDeriving
-    KindSignatures
-    LambdaCase
-    MultiParamTypeClasses
-    OverloadedLists
-    OverloadedStrings
-    PatternSynonyms
-    RankNTypes
-    RecordWildCards
-    ScopedTypeVariables
-    TypeFamilies
-
-  ghc-options:        -freverse-errors -O2 -Wall -main-is Main
+      Bench.Binary
+      Bench.Extension
+      Bench.Galois
+      Bench.Prime
+      Paths_galois_field
+  hs-source-dirs:
+      bench
+  default-extensions: LambdaCase RecordWildCards OverloadedStrings NoImplicitPrelude FlexibleInstances FlexibleContexts ScopedTypeVariables RankNTypes DataKinds DeriveFunctor DeriveGeneric GeneralizedNewtypeDeriving KindSignatures MultiParamTypeClasses OverloadedLists PatternSynonyms TypeFamilies
+  ghc-options: -freverse-errors -O2 -Wall -main-is Main
   build-depends:
-      base            >=4.10   && <5
-    , bitvec          >=1.0.2  && <1.1
-    , criterion       >=1.5    && <1.6
+      MonadRandom >=0.5.1 && <0.6
+    , QuickCheck >=2.13 && <2.14
+    , base >=4.10 && <5
+    , bitvec >=1.0.2 && <1.1
+    , criterion >=1.5 && <1.6
     , galois-field
-    , groups          >=0.4.1  && <0.5
-    , integer-gmp     >=1.0.2  && <1.1
-    , mod             >=0.1.0  && <0.2
-    , MonadRandom     >=0.5.1  && <0.6
-    , poly            >=0.3.2  && <0.5
-    , protolude       >=0.2    && <0.4
-    , QuickCheck      >=2.13   && <2.14
-    , semirings       >=0.5    && <0.6
-    , vector          >=0.12.0 && <0.13
-    , wl-pprint-text  >=1.2.0  && <1.3
-
-  default-language:   Haskell2010
+    , groups >=0.4.1 && <0.5
+    , integer-gmp >=1.0.2 && <1.1
+    , mod >=0.1.0 && <0.2
+    , poly >=0.3.2 && <0.5
+    , protolude >=0.2 && <0.3
+    , semirings >=0.5 && <0.6
+    , vector >=0.12.0 && <0.13
+    , wl-pprint-text >=1.2.0 && <1.3
+  default-language: Haskell2010

--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ default-extensions:
 
 dependencies:
   - base             >= 4.10   && < 5
-  - protolude        >= 0.2    && < 0.4
+  - protolude        >= 0.2    && < 0.3
   - bitvec           >= 1.0.2  && < 1.1
   - groups           >= 0.4.1  && < 0.5
   - integer-gmp      >= 1.0.2  && < 1.1

--- a/package.yaml
+++ b/package.yaml
@@ -28,7 +28,7 @@ default-extensions:
 
 dependencies:
   - base             >= 4.10   && < 5
-  - protolude        >= 0.2    && < 0.3
+  - protolude        >= 0.2    && < 0.4
   - bitvec           >= 1.0.2  && < 1.1
   - groups           >= 0.4.1  && < 0.5
   - integer-gmp      >= 1.0.2  && < 1.1

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        galois-field
-version:     1.0.2
+version:     1.0.3
 synopsis:    Galois field library
 description: An efficient implementation of Galois fields used in cryptography research
 maintainer:  Adjoint Inc (info@adjoint.io)

--- a/src/Data/Field/Galois/Binary.hs
+++ b/src/Data/Field/Galois/Binary.hs
@@ -91,7 +91,7 @@ instance KnownNat p => Fractional (Binary p) where
     (1, y) -> B y
     _      -> divZeroError
   {-# INLINE recip #-}
-  fromRational (x:%y) = fromInteger x / fromInteger y
+  fromRational rat = fromInteger (numerator rat) / fromInteger (denominator rat)
   {-# INLINABLE fromRational #-}
 
 -- Binary fields are numeric.

--- a/src/Data/Field/Galois/Extension.hs
+++ b/src/Data/Field/Galois/Extension.hs
@@ -109,7 +109,7 @@ instance IrreducibleMonic p k => Fractional (Extension p k) where
     where
       (g, y) = gcdExt x $ poly (witness :: Extension p k)
   {-# INLINABLE recip #-}
-  fromRational (x:%y) = fromInteger x / fromInteger y
+  fromRational rat = fromInteger (numerator rat) / fromInteger (denominator rat)
   {-# INLINABLE fromRational #-}
 
 -- Extension fields are numeric.

--- a/src/Data/Field/Galois/Unity.hs
+++ b/src/Data/Field/Galois/Unity.hs
@@ -9,6 +9,7 @@ module Data.Field.Galois.Unity
   , isRootOfUnity
   , toU
   , toU'
+  , fromU
   ) where
 
 import Protolude hiding (natVal)
@@ -115,3 +116,7 @@ toU x = let u = U x :: RootsOfUnity n k in
 toU' :: forall n k . (KnownNat n, GaloisField k) => k -> RootsOfUnity n k
 toU' = U
 {-# INLINABLE toU' #-}
+
+fromU :: forall n k . (KnownNat n, GaloisField k) => RootsOfUnity n k -> k
+fromU (U k) = k
+{-# INLINABLE fromU #-}


### PR DESCRIPTION
### Pull Request Checklist

- [ X] Update [ChangeLog.md](https://github.com/adjoint-io/galois-field/blob/master/ChangeLog.md)
- [ X] Tests are passing.
- [ X] Benchmarks are not regressing.

I've build serialisation in a separate library but unfortunately there is no equivalent to fromE for RootsOfUnity so have had to add one in.

Also the current bounds don't build when cabal selects protolude-0.3 because :% for rationals has been removed so I've included a fix.